### PR TITLE
Fix sizes and posive basis assumption.

### DIFF
--- a/calculator/api/exchange_api.py
+++ b/calculator/api/exchange_api.py
@@ -1,5 +1,6 @@
 import datetime
 import time
+from decimal import Decimal
 
 import requests
 
@@ -11,23 +12,23 @@ BASE_URL = "https://api.pro.coinbase.com/products/"
 
 class ExchangeApi:
 
-  def get_close(self, iso_time: str, pair: Pair) -> float:
-    url = BASE_URL + "{}/candles".format(pair.value)
+  def get_close(self, date_time: datetime, pair: Pair) -> float:
+    url = BASE_URL + "{}/candles".format(pair)
     response = requests.get(
       "{}?start={}&end={}&granularity=60".format(
         url,
-        iso_time,
-        get_next_minute(iso_time)
+        date_time.strftime(TIME_STRING_FORMAT),
+        get_next_minute(date_time)
       )
     )
     data = response.json()
     if "message" in data:
-      return self.__handle_error(data, iso_time, pair)
+      return self.__handle_error(data, date_time, pair)
 
     # last response comes first and close is the 4th index
-    return data[0][4]
+    return Decimal(data[0][4]).quantize(Decimal("0.01"))
 
-  def __handle_error(self, data: dict, iso_time: str, pair: Pair) -> float:
+  def __handle_error(self, data: dict, iso_time: datetime, pair: Pair) -> float:
     # Issue could be a rate limited by api
     if data["message"] == "Slow rate limit exceeded":
       print("API rate limit exceeded, pausing for 1 seconds")
@@ -37,8 +38,7 @@ class ExchangeApi:
                               .format(data["message"]))
 
 
-def get_next_minute(iso_time: str) -> str:
-  start_dt = datetime.datetime.strptime(iso_time, TIME_STRING_FORMAT)
+def get_next_minute(start_dt: datetime) -> str:
   end_dt = start_dt + datetime.timedelta(0, 60)
   return end_dt.strftime(TIME_STRING_FORMAT)
 

--- a/calculator/converters.py
+++ b/calculator/converters.py
@@ -6,7 +6,10 @@ from calculator.format import TIME_STRING_FORMAT, SIZE, PAIR, SIDE, TIME, PRICE,
   FEE, TOTAL, USD_PER_BTC, TOTAL_IN_USD, SIZE_UNIT, P_F_T_UNIT
 
 
-DECIMAL_CONVERTER = lambda x: Decimal(x) if x != "" else Decimal("nan")
+USD_CONVERTER = lambda x: (Decimal(x).quantize(Decimal("0.01"))
+                           if x != ""
+                           else Decimal("nan"))
+TEN_PLACE_CONVERTER = lambda x: Decimal(x).quantize(Decimal("0.0000000001"))
 PAIR_CONVERTER = lambda x: Pair[x.replace("-", "_")]
 SIDE_CONVERTER = lambda x: Side(x)
 TIME_CONVERTER = lambda x: datetime.strptime(x, TIME_STRING_FORMAT)
@@ -14,15 +17,15 @@ SIZE_UNIT_CONVERTER = lambda x: Asset(x)
 
 
 CONVERTERS = {
-  SIZE: DECIMAL_CONVERTER,
+  SIZE: TEN_PLACE_CONVERTER,
   PAIR: PAIR_CONVERTER,
   SIDE: SIDE_CONVERTER,
   TIME: TIME_CONVERTER,
-  PRICE: DECIMAL_CONVERTER,
-  FEE: DECIMAL_CONVERTER,
-  TOTAL: DECIMAL_CONVERTER,
-  USD_PER_BTC: DECIMAL_CONVERTER,
-  TOTAL_IN_USD: DECIMAL_CONVERTER,
+  PRICE: TEN_PLACE_CONVERTER,
+  FEE: TEN_PLACE_CONVERTER,
+  TOTAL: TEN_PLACE_CONVERTER,
+  USD_PER_BTC: USD_CONVERTER,
+  TOTAL_IN_USD: USD_CONVERTER,
   SIZE_UNIT: SIZE_UNIT_CONVERTER,
   P_F_T_UNIT: SIZE_UNIT_CONVERTER
 }

--- a/calculator/trade_types.py
+++ b/calculator/trade_types.py
@@ -29,19 +29,19 @@ class Asset(Enum):
 
 class Pair(Enum):
   BTC_USD = {"base": Asset.BTC, "quote": Asset.USD,
-             'base_increment': '0.00000001'}
+             'base_increment': '0.0000000001'}
   ETH_USD = {"base": Asset.ETH, "quote": Asset.USD,
-             'base_increment': '0.00000001'}
+             'base_increment': '0.0000000001'}
   ETH_BTC = {"base": Asset.ETH, "quote": Asset.BTC,
-             'base_increment': '0.00000001'}
+             'base_increment': '0.0000000001'}
   LTC_USD = {"base": Asset.LTC, "quote": Asset.USD,
-             'base_increment': '0.00000001'}
+             'base_increment': '0.0000000001'}
   LTC_BTC = {"base": Asset.LTC, "quote": Asset.BTC,
-             'base_increment': '0.00000001'}
+             'base_increment': '0.0000000001'}
   BCH_USD = {"base": Asset.BCH, "quote": Asset.USD,
-             'base_increment': '0.00000001'}
+             'base_increment': '0.0000000001'}
   BCH_BTC = {"base": Asset.BCH, "quote": Asset.BTC,
-             'base_increment': '0.00000001'}
+             'base_increment': '0.0000000001'}
 
   quantize = lambda self, x: x.quantize(Decimal(self.value["base_increment"]),
                                         rounding=ROUND_HALF_EVEN)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -29,7 +29,7 @@ def get_trade(
     trade_id: int = 3132964,
     product: Pair = Pair.ETH_BTC,
     side: Side = Side.SELL,
-    created_at: datetime = datetime(2018, 1, 2, 1, 18, 26, 406, pytz.UTC), # "2018-01-02T01:18:26.406Z"
+    created_at: datetime = datetime(2018, 1, 2, 1, 18, 26, 406, pytz.UTC),
     size: Decimal = Decimal("0.00768977"),
     price: Decimal = Decimal("0.0575"),
     fee: Decimal = Decimal("0"),
@@ -54,8 +54,13 @@ def get_trade(
   :return Series representing the trade
 
   """
+  # Values are assumed to be passed in as positive, this is a sanity check
+  if price < 0 or size < 0 or fee < 0 or (
+    not usd_per_btc.is_nan() and usd_per_btc < 0
+  ):
+    raise ValueError("Passed negative value to helper method.")
   quote: Asset = product.get_quote_asset()
-  total = size * price + fee if Side.BUY == side else size * price - fee
+  total = - price * size - fee if Side.BUY == side else price * size -fee
   if quote == Asset.USD:
     usd_per_btc = Decimal("nan")
     value = total


### PR DESCRIPTION
Closes #8. Assumptions about how trade totals would all be positive has
been corrected. Sizes have been properly quantized when importing csv to
avoid off by nothing issues that are likely caused by pandas from_csv
converting numbers to floats automatically before using a type
converter, thats a guess though.