### PR TITLE
Wash trade logic now coniders purchases 30 days prior to loss

### DIFF
--- a/calculator/api/exchange_api.py
+++ b/calculator/api/exchange_api.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 import requests
 
+from calculator.converters import USD_CONVERTER
 from calculator.format import TIME_STRING_FORMAT
 from calculator.trade_types import Pair
 
@@ -26,7 +27,7 @@ class ExchangeApi:
       return self.__handle_error(data, date_time, pair)
 
     # last response comes first and close is the 4th index
-    return Decimal(data[0][4]).quantize(Decimal("0.01"))
+    return USD_CONVERTER(data[0][4])
 
   def __handle_error(self, data: dict, iso_time: datetime, pair: Pair) -> float:
     # Issue could be a rate limited by api

--- a/calculator/converters.py
+++ b/calculator/converters.py
@@ -1,14 +1,13 @@
-from decimal import Decimal
+from decimal import Decimal, ROUND_UP
 from datetime import datetime
 
 from calculator.trade_types import Pair, Side, Asset
-from calculator.format import TIME_STRING_FORMAT, SIZE, PAIR, SIDE, TIME, PRICE, \
-  FEE, TOTAL, USD_PER_BTC, TOTAL_IN_USD, SIZE_UNIT, P_F_T_UNIT
+from calculator.format import TIME_STRING_FORMAT, SIZE, PAIR, SIDE, TIME, \
+  PRICE, FEE, TOTAL, USD_PER_BTC, TOTAL_IN_USD, SIZE_UNIT, P_F_T_UNIT
 
 
-USD_CONVERTER = lambda x: (Decimal(x).quantize(Decimal("0.01"))
-                           if x != ""
-                           else Decimal("nan"))
+USD_CONVERTER = lambda x: USD_ROUNDER(Decimal(x)) if x != "" else Decimal("nan")
+USD_ROUNDER = lambda x: x.quantize(Decimal("0.01"), rounding=ROUND_UP)
 TEN_PLACE_CONVERTER = lambda x: Decimal(x).quantize(Decimal("0.0000000001"))
 PAIR_CONVERTER = lambda x: Pair[x.replace("-", "_")]
 SIDE_CONVERTER = lambda x: Side(x)

--- a/calculator/tax_calculator.py
+++ b/calculator/tax_calculator.py
@@ -9,7 +9,7 @@ from calculator.api.exchange_api import ExchangeApi
 from calculator.format import (
   PAIR, TIME, SIDE, TOTAL, TOTAL_IN_USD, USD_PER_BTC, ADJUSTED_VALUE,
   WASH_P_L_IDS, ADJUSTED_SIZE, TIME_STRING_FORMAT)
-from calculator.converters import CONVERTERS
+from calculator.converters import CONVERTERS, USD_CONVERTER
 from calculator.trade_types import Asset, Side, Pair
 from calculator.trade_processor.trade_processor import TradeProcessor
 
@@ -28,11 +28,7 @@ def calculate_all(path, cb_name, trade_name):
       converters=CONVERTERS
     )
   except FileNotFoundError as e:
-    print(
-      "STEP 1: Finding BTC-USD for non USD Quote trades. API limits 3 requests"
-      " per second so this will take over one minute per 90 non USD quote"
-      " trades."
-    )
+    # check for columns in case they are named differently but has usd per btc
     cost_basis_df = pd.read_csv(
       "{}{}".format(path, cb_name),
       converters=CONVERTERS
@@ -40,6 +36,11 @@ def calculate_all(path, cb_name, trade_name):
     trades_df = pd.read_csv(
       "{}{}".format(path, trade_name),
       converters=CONVERTERS
+    )
+    print(
+      "STEP 1: Finding BTC-USD for non USD Quote trades. API limits 3 requests"
+      " per second so this will take over one minute per 90 non USD quote"
+      " trades."
     )
     print("\nGrabbing usd per btc for cost basis trades")
     add_usd_per(cost_basis_df)
@@ -175,3 +176,4 @@ def add_usd_per(df):
   ]
   df.loc[~usd_not_base_mask, TOTAL_IN_USD] = df.loc[
     ~usd_not_base_mask, TOTAL]
+  df[TOTAL_IN_USD].apply(USD_ROUNDER)

--- a/calculator/trade_processor/profit_and_loss.py
+++ b/calculator/trade_processor/profit_and_loss.py
@@ -1,8 +1,10 @@
-from decimal import Decimal
+from decimal import Decimal, ROUND_UP
 import pprint
 from typing import List
 
 from pandas import Series
+
+from calculator.converters import USD_CONVERTER, USD_ROUNDER
 from calculator.format import ID, PAIR, TOTAL_IN_USD, SIZE, \
   USD_PER_BTC, SIDE, PRICE, FEE, ADJUSTED_VALUE, WASH_P_L_IDS, ADJUSTED_SIZE, \
   TOTAL
@@ -74,7 +76,7 @@ class ProfitAndLoss:
       }
     )
 
-  def wash_loss(self, wash_trade: Series):
+  def wash_loss(self, wash_trade: Series,):
     self.validate_wash()
     self.wash_loss_basis_ids.append(wash_trade[ID])
     wash_trade[WASH_P_L_IDS].append(self.id)
@@ -85,7 +87,8 @@ class ProfitAndLoss:
       adj_loss = self.taxed_profit_and_loss
     else:
       adj_size = size
-      adj_loss = self.taxed_profit_and_loss * adj_size / self.unwashed_size
+      adj_loss = USD_ROUNDER(self.taxed_profit_and_loss * adj_size /
+                               self.unwashed_size)
 
     self.taxed_profit_and_loss -= adj_loss
     if self.asset == wash_trade[PAIR].get_base_asset():


### PR DESCRIPTION
Wash trades were only being considered for the buy backs 30 days after
the loss, this changes that so that any buy back thirty days before or
after the loss is considered for invalidating the loss